### PR TITLE
Support PSR-15 http-middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,13 @@ After this, you can access the session data inside any middleware that
 has access to the `Psr\Http\Message\ServerRequestInterface` attributes:
 
 ```php
-$app->get('/get', function (ServerRequestInterface $request, ResponseInterface $response) : ResponseInterface {
+$app->get('/get', function (ServerRequestInterface $request, DelegateInterface $delegate) : ResponseInterface {
     /* @var \PSR7Sessions\Storageless\Session\Data $session */
     $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
     $session->set('counter', $session->get('counter', 0) + 1);
 
-    $response
-        ->getBody()
-        ->write('Counter Value: ' . $session->get('counter'));
+    $response = new Response();
+    $response->getBody()->write('Counter Value: ' . $session->get('counter'));
 
     return $response;
 });

--- a/composer.json
+++ b/composer.json
@@ -21,14 +21,14 @@
         }
     ],
     "require": {
-        "php":                             "~7.0",
-        "psr/http-message":                "^1.0",
-        "lcobucci/jwt":                    "^3.2",
-        "zendframework/zend-stratigility": "^2.0",
-        "dflydev/fig-cookies":             "^1.0"
+        "php":                          "~7.0",
+        "psr/http-message":             "^1.0",
+        "lcobucci/jwt":                 "^3.2",
+        "dflydev/fig-cookies":          "^1.0",
+        "http-interop/http-middleware": "^0.4.1"
     },
     "require-dev": {
-        "phpunit/phpunit":              "^6.0",
+        "phpunit/phpunit":              "^5.0",
         "zendframework/zend-diactoros": "^1.1",
         "humbug/humbug":                "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,12 +23,12 @@
     "require": {
         "php":                             "~7.0",
         "psr/http-message":                "^1.0",
-        "lcobucci/jwt":                    "^3.1",
-        "zendframework/zend-stratigility": "^1.1",
+        "lcobucci/jwt":                    "^3.2",
+        "zendframework/zend-stratigility": "^2.0",
         "dflydev/fig-cookies":             "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit":              "^5.0",
+        "phpunit/phpunit":              "^6.0",
         "zendframework/zend-diactoros": "^1.1",
         "humbug/humbug":                "dev-master"
     },

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -525,7 +525,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
         SessionMiddleware $middleware,
         ServerRequestInterface $request,
         DelegateInterface $delegate
-    ): ResponseInterface {
+    ) : ResponseInterface {
         $initialResponse = new Response();
         $response = $middleware->process($request, $delegate);
 
@@ -538,7 +538,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
         SessionMiddleware $middleware,
         ServerRequestInterface $request,
         DelegateInterface $delegate
-    ): ResponseInterface {
+    ) : ResponseInterface {
         $initialResponse = new Response();
         $response = $middleware->process($request, $delegate);
 
@@ -558,7 +558,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
         SessionMiddleware $middleware,
         ServerRequestInterface $request,
         DelegateInterface $delegate
-    ): ResponseInterface {
+    ) : ResponseInterface {
         $initialResponse = new Response();
         $response = $middleware->process($request, $delegate);
 
@@ -579,7 +579,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
      *
      * @return string
      */
-    private function createToken(SessionMiddleware $middleware, \DateTime $issuedAt, \DateTime $expiration): string
+    private function createToken(SessionMiddleware $middleware, \DateTime $issuedAt, \DateTime $expiration) : string
     {
         return (string) (new Builder())
             ->setIssuedAt($issuedAt->getTimestamp())
@@ -592,10 +592,10 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
     /**
      * @return DelegateInterface
      */
-    private function emptyValidationDelegate(): DelegateInterface
+    private function emptyValidationDelegate() : DelegateInterface
     {
         return $this->fakeDelegate(
-            function (ServerRequestInterface $request) {
+            function (ServerRequestInterface $request) : ResponseInterface {
                 /* @var $session SessionInterface */
                 $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
@@ -612,10 +612,10 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
      *
      * @return DelegateInterface
      */
-    private function writingDelegate($value = 'bar'): DelegateInterface
+    private function writingDelegate($value = 'bar') : DelegateInterface
     {
         return $this->fakeDelegate(
-            function (ServerRequestInterface $request) use ($value) {
+            function (ServerRequestInterface $request) use ($value) : ResponseInterface {
                 /* @var $session SessionInterface */
                 $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
                 $session->set('foo', $value);
@@ -628,10 +628,10 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
     /**
      * @return DelegateInterface
      */
-    private function defaultDelegate(): DelegateInterface
+    private function defaultDelegate() : DelegateInterface
     {
         return $this->fakeDelegate(
-            function (ServerRequestInterface $request) {
+            function (ServerRequestInterface $request) : ResponseInterface {
                 return new Response();
             }
         );
@@ -642,13 +642,11 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
      *
      * @return DelegateInterface
      */
-    private function fakeDelegate(callable $callback): DelegateInterface
+    private function fakeDelegate(callable $callback) : DelegateInterface
     {
         $delegate = $this->createMock(DelegateInterface::class);
 
-        $delegate->expects($this->once())->method('process')->willReturnCallback($callback)->with(
-            self::isInstanceOf(ServerRequestInterface::class)
-        );
+        $delegate->expects($this->once())->method('process')->willReturnCallback($callback);
 
         return $delegate;
     }
@@ -656,9 +654,9 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
     /**
      * @param ResponseInterface $response
      *
-     * @return \Zend\Diactoros\ServerRequest
+     * @return ServerRequestInterface
      */
-    private function requestWithResponseCookies(ResponseInterface $response): ServerRequestInterface
+    private function requestWithResponseCookies(ResponseInterface $response) : ServerRequestInterface
     {
         return (new ServerRequest())->withCookieParams([
             SessionMiddleware::DEFAULT_COOKIE => $this->getCookie($response)->getValue()
@@ -667,11 +665,14 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
 
     /**
      * @param ResponseInterface $response
+     * @param string            $name
      *
      * @return SetCookie
      */
-    private function getCookie(ResponseInterface $response, string $name = SessionMiddleware::DEFAULT_COOKIE): SetCookie
-    {
+    private function getCookie(
+        ResponseInterface $response,
+        string $name = SessionMiddleware::DEFAULT_COOKIE
+    ) : SetCookie {
         return FigResponseCookies::get($response, $name);
     }
 
@@ -680,7 +681,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
      *
      * @return Signer
      */
-    private function getSigner(SessionMiddleware $middleware): Signer
+    private function getSigner(SessionMiddleware $middleware) : Signer
     {
         return $this->getPropertyValue($middleware, 'signer');
     }
@@ -690,7 +691,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
      *
      * @return string
      */
-    private function getSignatureKey(SessionMiddleware $middleware): string
+    private function getSignatureKey(SessionMiddleware $middleware) : string
     {
         return $this->getPropertyValue($middleware, 'signatureKey');
     }

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -23,6 +23,8 @@ namespace PSR7SessionsTest\Storageless\Http;
 use DateTimeImmutable;
 use Dflydev\FigCookies\FigResponseCookies;
 use Dflydev\FigCookies\SetCookie;
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer;
@@ -39,14 +41,13 @@ use PSR7Sessions\Storageless\Time\SystemCurrentTime;
 use PSR7SessionsTest\Storageless\Time\FakeCurrentTime;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
-use Zend\Stratigility\MiddlewareInterface;
 
 final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
 {
     public function testFromSymmetricKeyDefaultsUsesASecureCookie()
     {
         $response = SessionMiddleware::fromSymmetricKeyDefaults('not relevant', 100)
-            ->__invoke(new ServerRequest(), new Response(), $this->writingMiddleware());
+            ->process(new ServerRequest(), $this->writingDelegate());
 
         $cookie = $this->getCookie($response);
 
@@ -62,7 +63,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                 file_get_contents(__DIR__ . '/../../keys/public_key.pem'),
                 200
             )
-            ->__invoke(new ServerRequest(), new Response(), $this->writingMiddleware());
+            ->process(new ServerRequest(), $this->writingDelegate());
 
         $cookie = $this->getCookie($response);
 
@@ -75,7 +76,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
      */
     public function testSkipsInjectingSessionCookieOnEmptyContainer(SessionMiddleware $middleware)
     {
-        $response = $this->ensureSameResponse($middleware, new ServerRequest(), $this->emptyValidationMiddleware());
+        $response = $this->ensureSameResponse($middleware, new ServerRequest(), $this->emptyValidationDelegate());
 
         self::assertNull($this->getCookie($response)->getValue());
     }
@@ -85,7 +86,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
      */
     public function testExtractsSessionContainerFromEmptyRequest(SessionMiddleware $middleware)
     {
-        $this->ensureSameResponse($middleware, new ServerRequest(), $this->emptyValidationMiddleware());
+        $this->ensureSameResponse($middleware, new ServerRequest(), $this->emptyValidationDelegate());
     }
 
     /**
@@ -93,10 +94,8 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
      */
     public function testInjectsSessionInResponseCookies(SessionMiddleware $middleware)
     {
-        $initialResponse = new Response();
-        $response = $middleware(new ServerRequest(), $initialResponse, $this->writingMiddleware());
+        $response = $this->ensureNotSameResponse($middleware, new ServerRequest(), $this->writingDelegate());
 
-        self::assertNotSame($initialResponse, $response);
         self::assertEmpty($this->getCookie($response, 'non-existing')->getValue());
         self::assertInstanceOf(Token::class, (new Parser())->parse($this->getCookie($response)->getValue()));
     }
@@ -108,8 +107,8 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
     {
         $sessionValue = uniqid('', true);
 
-        $checkingMiddleware = $this->fakeMiddleware(
-            function (ServerRequestInterface $request, ResponseInterface $response) use ($sessionValue) {
+        $checkingDelegate = $this->fakeDelegate(
+            function (ServerRequestInterface $request) use ($sessionValue) {
                 /* @var $session SessionInterface */
                 $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
@@ -124,18 +123,17 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                     . 'non-modified session containers are not to be re-serialized into a token'
                 );
 
-                return $response;
+                return new Response();
             }
         );
 
-        $firstResponse = $middleware(new ServerRequest(), new Response(), $this->writingMiddleware($sessionValue));
+        $firstResponse = $middleware->process(new ServerRequest(), $this->writingDelegate($sessionValue));
 
         $initialResponse = new Response();
 
-        $response = $middleware(
+        $response = $middleware->process(
             $this->requestWithResponseCookies($firstResponse),
-            $initialResponse,
-            $checkingMiddleware
+            $checkingDelegate
         );
 
         self::assertNotSame($initialResponse, $response);
@@ -155,7 +153,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                 )
             ]);
 
-        $this->ensureSameResponse($middleware, $expiredToken, $this->emptyValidationMiddleware());
+        $this->ensureSameResponse($middleware, $expiredToken, $this->emptyValidationDelegate());
     }
 
     /**
@@ -172,7 +170,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                 )
             ]);
 
-        $this->ensureSameResponse($middleware, $tokenInFuture, $this->emptyValidationMiddleware());
+        $this->ensureSameResponse($middleware, $tokenInFuture, $this->emptyValidationDelegate());
     }
 
     /**
@@ -189,7 +187,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                     ->getToken()
             ]);
 
-        $this->ensureSameResponse($middleware, $unsignedToken, $this->emptyValidationMiddleware());
+        $this->ensureSameResponse($middleware, $unsignedToken, $this->emptyValidationDelegate());
     }
 
     /**
@@ -206,7 +204,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                     ->getToken()
             ]);
 
-        $this->ensureSameResponse($middleware, $unsignedToken);
+        $this->ensureSameResponse($middleware, $unsignedToken, $this->defaultDelegate());
     }
 
     public function testWillRefreshTokenWithIssuedAtExactlyAtTokenRefreshTimeThreshold()
@@ -240,7 +238,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                     ->getToken()
             ]);
 
-        $cookie = $this->getCookie($middleware->__invoke($requestWithTokenIssuedInThePast, new Response()));
+        $cookie = $this->getCookie($middleware->process($requestWithTokenIssuedInThePast, $this->defaultDelegate()));
 
         $token = (new Parser())->parse($cookie->getValue());
 
@@ -255,10 +253,10 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->ensureSameResponse(
             $middleware,
             $this->requestWithResponseCookies(
-                $middleware(new ServerRequest(), new Response(), $this->writingMiddleware())
+                $middleware->process(new ServerRequest(), $this->writingDelegate())
             ),
-            $this->fakeMiddleware(
-                function (ServerRequestInterface $request, ResponseInterface $response) {
+            $this->fakeDelegate(
+                function (ServerRequestInterface $request) {
                     /* @var $session SessionInterface */
                     $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
@@ -267,7 +265,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
 
                     self::assertFalse($session->hasChanged());
 
-                    return $response;
+                    return new Response();
                 }
             )
         );
@@ -281,16 +279,16 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->ensureClearsSessionCookie(
             $middleware,
             $this->requestWithResponseCookies(
-                $middleware(new ServerRequest(), new Response(), $this->writingMiddleware())
+                $middleware->process(new ServerRequest(), $this->writingDelegate())
             ),
-            $this->fakeMiddleware(
-                function (ServerRequestInterface $request, ResponseInterface $response) {
+            $this->fakeDelegate(
+                function (ServerRequestInterface $request) {
                     /* @var $session SessionInterface */
                     $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
                     $session->clear();
 
-                    return $response;
+                    return new Response();
                 }
             )
         );
@@ -304,7 +302,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->ensureSameResponse(
             $middleware,
             (new ServerRequest())->withCookieParams([SessionMiddleware::DEFAULT_COOKIE => 'malformed content']),
-            $this->emptyValidationMiddleware()
+            $this->emptyValidationDelegate()
         );
     }
 
@@ -323,9 +321,9 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
         $this->ensureSameResponse(
             $middleware,
             $this->requestWithResponseCookies(
-                $middleware(new ServerRequest(), new Response(), $this->writingMiddleware())
+                $middleware->process(new ServerRequest(), $this->writingDelegate())
             ),
-            $this->emptyValidationMiddleware()
+            $this->emptyValidationDelegate()
         );
     }
 
@@ -350,10 +348,8 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
             123
         );
 
-        $initialResponse = new Response();
-        $response = $middleware(new ServerRequest(), $initialResponse, $this->writingMiddleware());
+        $response = $this->ensureNotSameResponse($middleware, new ServerRequest(), $this->writingDelegate());
 
-        self::assertNotSame($initialResponse, $response);
         self::assertNull($this->getCookie($response)->getValue());
 
         $tokenCookie = $this->getCookie($response, 'a-different-cookie-name');
@@ -384,16 +380,15 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                     ->getToken()
             ]);
 
-        $middleware(
+        $middleware->process(
             $request,
-            new Response(),
-            $this->fakeMiddleware(function (ServerRequestInterface $request, ResponseInterface $response) {
+            $this->fakeDelegate(function (ServerRequestInterface $request) {
                 self::assertInstanceOf(
                     SessionInterface::class,
                     $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE)
                 );
 
-                return $response;
+                return new Response();
             })
         );
     }
@@ -422,10 +417,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                     ->getToken()
             ]);
 
-        $initialResponse = new Response();
-        $response = $middleware($expiringToken, $initialResponse);
-
-        self::assertNotSame($initialResponse, $response);
+        $response = $this->ensureNotSameResponse($middleware, $expiringToken, $this->writingDelegate());
 
         $tokenCookie = $this->getCookie($response);
 
@@ -456,7 +448,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                     ->getToken()
             ]);
 
-        $this->ensureSameResponse($middleware, $validToken);
+        $this->ensureSameResponse($middleware, $validToken, $this->defaultDelegate());
     }
 
     /**
@@ -493,7 +485,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
             $this
                 ->getCookie(
                     SessionMiddleware::fromSymmetricKeyDefaults('not relevant', 100)
-                        ->__invoke(new ServerRequest(), new Response(), $this->writingMiddleware())
+                        ->process(new ServerRequest(), $this->writingDelegate())
                 )
                 ->getPath()
         );
@@ -517,48 +509,61 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
                             file_get_contents(__DIR__ . '/../../keys/public_key.pem'),
                             200
                         )
-                        ->__invoke(new ServerRequest(), new Response(), $this->writingMiddleware())
+                        ->process(new ServerRequest(), $this->writingDelegate())
                 )
                 ->getPath()
         );
     }
 
     /**
-     * @param SessionMiddleware $middleware
+     * @param SessionMiddleware      $middleware
      * @param ServerRequestInterface $request
-     * @param callable $next
+     * @param DelegateInterface      $delegate
      *
      * @return ResponseInterface
      */
     private function ensureSameResponse(
         SessionMiddleware $middleware,
         ServerRequestInterface $request,
-        callable $next = null
+        DelegateInterface $delegate
     ): ResponseInterface {
         $initialResponse = new Response();
-        $response = $middleware($request, $initialResponse, $next);
+        $response = $middleware->process($request, $delegate);
 
-        self::assertSame($initialResponse, $response);
+        self::assertSame($initialResponse->getHeaders(), $response->getHeaders());
+
+        return $response;
+    }
+
+    private function ensureNotSameResponse(
+        SessionMiddleware $middleware,
+        ServerRequestInterface $request,
+        DelegateInterface $delegate
+    ): ResponseInterface {
+        $initialResponse = new Response();
+        $response = $middleware->process($request, $delegate);
+
+        self::assertNotSame($initialResponse->getHeaders(), $response->getHeaders());
 
         return $response;
     }
 
     /**
-     * @param SessionMiddleware $middleware
+     * @param SessionMiddleware      $middleware
      * @param ServerRequestInterface $request
-     * @param callable $next
+     * @param DelegateInterface      $delegate
      *
      * @return ResponseInterface
      */
     private function ensureClearsSessionCookie(
         SessionMiddleware $middleware,
         ServerRequestInterface $request,
-        callable $next = null
+        DelegateInterface $delegate
     ): ResponseInterface {
         $initialResponse = new Response();
-        $response = $middleware($request, $initialResponse, $next);
+        $response = $middleware->process($request, $delegate);
 
-        self::assertNotSame($initialResponse, $response);
+        self::assertNotSame($initialResponse->getHeaders(), $response->getHeaders());
 
         $cookie = $this->getCookie($response);
 
@@ -586,19 +591,19 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return MiddlewareInterface
+     * @return DelegateInterface
      */
-    private function emptyValidationMiddleware(): MiddlewareInterface
+    private function emptyValidationDelegate(): DelegateInterface
     {
-        return $this->fakeMiddleware(
-            function (ServerRequestInterface $request, ResponseInterface $response) {
+        return $this->fakeDelegate(
+            function (ServerRequestInterface $request) {
                 /* @var $session SessionInterface */
                 $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
                 self::assertInstanceOf(SessionInterface::class, $session);
                 self::assertTrue($session->isEmpty());
 
-                return $response;
+                return new Response();
             }
         );
     }
@@ -606,17 +611,29 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
     /**
      * @param string $value
      *
-     * @return MiddlewareInterface
+     * @return DelegateInterface
      */
-    private function writingMiddleware($value = 'bar'): MiddlewareInterface
+    private function writingDelegate($value = 'bar'): DelegateInterface
     {
-        return $this->fakeMiddleware(
-            function (ServerRequestInterface $request, ResponseInterface $response) use ($value) {
+        return $this->fakeDelegate(
+            function (ServerRequestInterface $request) use ($value) {
                 /* @var $session SessionInterface */
                 $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
                 $session->set('foo', $value);
 
-                return $response;
+                return new Response();
+            }
+        );
+    }
+
+    /**
+     * @return DelegateInterface
+     */
+    private function defaultDelegate(): DelegateInterface
+    {
+        return $this->fakeDelegate(
+            function (ServerRequestInterface $request) {
+                return new Response();
             }
         );
     }
@@ -624,22 +641,20 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
     /**
      * @param callable $callback
      *
-     * @return MiddlewareInterface
+     * @return DelegateInterface
      */
-    private function fakeMiddleware(callable $callback): MiddlewareInterface
+    private function fakeDelegate(callable $callback): DelegateInterface
     {
-        $middleware = $this->createMock(MiddlewareInterface::class);
+        $delegate = $this->createMock(DelegateInterface::class);
 
-        $middleware->expects($this->once())
-           ->method('__invoke')
-           ->willReturnCallback($callback)
-           ->with(
-               self::isInstanceOf(ServerRequestInterface::class),
-               self::isInstanceOf(ResponseInterface::class),
-               self::logicalOr(self::isNull(), self::isType('callable'))
-           );
+        $delegate->expects($this->once())
+            ->method('process')
+            ->willReturnCallback($callback)
+            ->with(
+                self::isInstanceOf(ServerRequestInterface::class)
+            );
 
-        return $middleware;
+        return $delegate;
     }
 
     /**

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -647,12 +647,9 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
     {
         $delegate = $this->createMock(DelegateInterface::class);
 
-        $delegate->expects($this->once())
-            ->method('process')
-            ->willReturnCallback($callback)
-            ->with(
-                self::isInstanceOf(ServerRequestInterface::class)
-            );
+        $delegate->expects($this->once())->method('process')->willReturnCallback($callback)->with(
+            self::isInstanceOf(ServerRequestInterface::class)
+        );
 
         return $delegate;
     }

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -24,7 +24,6 @@ use DateTimeImmutable;
 use Dflydev\FigCookies\FigResponseCookies;
 use Dflydev\FigCookies\SetCookie;
 use Interop\Http\ServerMiddleware\DelegateInterface;
-use Interop\Http\ServerMiddleware\MiddlewareInterface;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer;


### PR DESCRIPTION
This PR removes the stratigilty dependency and adds support for [PSR-15 http-middleware](https://github.com/http-interop/http-middleware). 

Currently this package doesn't support stratigility 2.0. In a chat with @Ocramius, he told me that creating a new major version was the best approach. Since stratigility moves towards PSR-15 http-middleware, this package might as well. It would loose its stratigility dependency in favor of a PSR standard and make this package usable in other future PSR-15 frameworks.

- [x] replace Stratigility dependency with PSR-15 http-middleware
- [x] fix tests
- [x] update docs
- [ ] wait for PSR-15 being accepted