### PR TITLE
Delay signature verification properly

### DIFF
--- a/src/Storageless/Http/SessionMiddleware.php
+++ b/src/Storageless/Http/SessionMiddleware.php
@@ -248,25 +248,21 @@ final class SessionMiddleware implements MiddlewareInterface
     private function appendToken(SessionInterface $sessionContainer, Response $response, Token $token = null) : Response
     {
         $sessionContainerChanged = $sessionContainer->hasChanged();
-        $sessionContainerEmpty   = $sessionContainer->isEmpty();
 
-        if ($sessionContainerChanged && $sessionContainerEmpty) {
+        if ($sessionContainerChanged && $sessionContainer->isEmpty()) {
             return FigResponseCookies::set($response, $this->getExpirationCookie());
         }
 
-        if ($sessionContainerChanged || (! $sessionContainerEmpty && $token && $this->shouldTokenBeRefreshed($token))) {
+        if ($sessionContainerChanged || ($this->shouldTokenBeRefreshed($token) && ! $sessionContainer->isEmpty())) {
             return FigResponseCookies::set($response, $this->getTokenCookie($sessionContainer));
         }
 
         return $response;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    private function shouldTokenBeRefreshed(Token $token) : bool
+    private function shouldTokenBeRefreshed(Token $token = null) : bool
     {
-        if (! $token->hasClaim(self::ISSUED_AT_CLAIM)) {
+        if (! $token || ! $token->hasClaim(self::ISSUED_AT_CLAIM)) {
             return false;
         }
 

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -26,6 +26,7 @@ use Dflydev\FigCookies\SetCookie;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer;
+use Lcobucci\JWT\Signature;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\Token;
 use PHPUnit_Framework_TestCase;
@@ -373,6 +374,7 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
         $signer = $this->createMock(Signer::class);
 
         $signer->expects($this->never())->method('verify');
+        $signer->method('getAlgorithmId')->willReturn('HS256');
 
         $currentTimeProvider = new SystemCurrentTime();
         $setCookie  = SetCookie::create(SessionMiddleware::DEFAULT_COOKIE);
@@ -381,6 +383,8 @@ final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
             ->withCookieParams([
                 SessionMiddleware::DEFAULT_COOKIE => (string) (new Builder())
                     ->set(SessionMiddleware::SESSION_CLAIM, DefaultSessionData::fromTokenData(['foo' => 'bar']))
+                    ->setIssuedAt(time())
+                    ->sign(new Sha256(), 'foo')
                     ->getToken()
             ]);
 


### PR DESCRIPTION
As explained on #63 the middleware was always actually trying to verify the signature.
Moving `sessionContainer#isEmpty()` calls to the end of the expressions delays the initialisation properly.