### PR TITLE
Update HumBug version in composer.json. Fixes #69

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "phpunit/phpunit":              "^5.0",
         "zendframework/zend-diactoros": "^1.1",
-        "humbug/humbug":                "dev-master"
+        "humbug/humbug":                "~1.0@dev"
     },
     "replace": {
         "ocramius/psr7-session": "self.version"


### PR DESCRIPTION
The current version is pointing to dev-master which is breaking the installation with:

composer install

Changing the version to the latest dev branch sorts this issue.

This is a dev only dependency, but is blocking the use of the example as stated on the documentation.