### PR TITLE
Initial support for zend-stratigility 2.0, #68

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
         "php":                             "^7.1",
         "psr/http-message":                "^1.0",
         "lcobucci/jwt":                    "^3.1",
-        "zendframework/zend-stratigility": "^1.1",
+        "zendframework/zend-stratigility": "^1.1 || ^2.0",
         "dflydev/fig-cookies":             "^1.0",
         "lcobucci/clock":                  "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit":              "^5.0",
         "zendframework/zend-diactoros": "^1.1",
-        "humbug/humbug":                "dev-master"
+        "humbug/humbug":                "1.0.0-alpha2"
     },
     "replace": {
         "ocramius/psr7-session": "self.version"


### PR DESCRIPTION
Following comment here:
https://github.com/psr7-sessions/storageless/issues/68

Added zend-stratigility 2.0 to composer to try out before the PSR15 support is merged #59.  This could help installing in expressive 2.+.

