### PR TITLE
PSR-15 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 This is a list of changes/improvements that were introduced in PSR7Session
 
+## 4.0.0
+
+This release aligns the `PSR7Sessions\Storageless\Http\SessionMiddleware` to
+the [PSR-15 `php-fig/http-server-middleware`](https://github.com/php-fig/http-server-middleware/tree/1.0.0)
+specification.
+
+This means that the signature of `PSR7Sessions\Storageless\Http\SessionMiddleware`
+changed, and therefore you need to look for usages of this class and verify
+if the new signature is compatible with your API
+
+Specifically, `PSR7Sessions\Storageless\Http\SessionMiddleware#__invoke()`
+was removed.
+
 ## 3.0.1
 
 This release fixes an issue that prevented effective lazy-loading of the

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "psr/http-message":                "^1.0.1",
         "psr/http-server-handler":         "^1.0.0",
         "psr/http-server-middleware":      "^1.0.0",
-        "lcobucci/jwt":                    "^3.2.1",
-        "zendframework/zend-stratigility": "^1.1",
+        "lcobucci/jwt":                    "^3.2.2",
         "dflydev/fig-cookies":             "^1.0.2",
         "lcobucci/clock":                  "^1.1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,16 +22,17 @@
     ],
     "require": {
         "php":                             "^7.1",
-        "psr/http-message":                "^1.0",
-        "lcobucci/jwt":                    "^3.1",
+        "psr/http-message":                "^1.0.1",
+        "psr/http-server-handler":         "^1.0.0",
+        "lcobucci/jwt":                    "^3.2.1",
         "zendframework/zend-stratigility": "^1.1",
-        "dflydev/fig-cookies":             "^1.0",
-        "lcobucci/clock":                  "^1.0"
+        "dflydev/fig-cookies":             "^1.0.2",
+        "lcobucci/clock":                  "^1.1.0"
     },
     "require-dev": {
-        "phpunit/phpunit":              "^5.0",
-        "zendframework/zend-diactoros": "^1.1",
-        "humbug/humbug":                "dev-master"
+        "phpunit/phpunit":              "^6.5.5",
+        "zendframework/zend-diactoros": "^1.7.0",
+        "humbug/humbug":                "^1.0.0-rc.0"
     },
     "replace": {
         "ocramius/psr7-session": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "php":                             "^7.1",
         "psr/http-message":                "^1.0.1",
         "psr/http-server-handler":         "^1.0.0",
+        "psr/http-server-middleware":      "^1.0.0",
         "lcobucci/jwt":                    "^3.2.1",
         "zendframework/zend-stratigility": "^1.1",
         "dflydev/fig-cookies":             "^1.0.2",

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -28,10 +28,9 @@ use Lcobucci\Clock\SystemClock;
 use Lcobucci\JWT\Builder;
 use Lcobucci\JWT\Parser;
 use Lcobucci\JWT\Signer;
-use Lcobucci\JWT\Signature;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\Token;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use PSR7Sessions\Storageless\Http\SessionMiddleware;
@@ -41,7 +40,7 @@ use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
 use Zend\Stratigility\MiddlewareInterface;
 
-final class SessionMiddlewareTest extends PHPUnit_Framework_TestCase
+final class SessionMiddlewareTest extends TestCase
 {
     public function testFromSymmetricKeyDefaultsUsesASecureCookie() : void
     {

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -31,21 +31,22 @@ use Lcobucci\JWT\Signer;
 use Lcobucci\JWT\Signer\Hmac\Sha256;
 use Lcobucci\JWT\Token;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use PSR7Sessions\Storageless\Http\SessionMiddleware;
 use PSR7Sessions\Storageless\Session\DefaultSessionData;
 use PSR7Sessions\Storageless\Session\SessionInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
-use Zend\Stratigility\MiddlewareInterface;
 
 final class SessionMiddlewareTest extends TestCase
 {
     public function testFromSymmetricKeyDefaultsUsesASecureCookie() : void
     {
         $response = SessionMiddleware::fromSymmetricKeyDefaults('not relevant', 100)
-            ->__invoke(new ServerRequest(), new Response(), $this->writingMiddleware());
+            ->process(new ServerRequest(), $this->writingMiddleware());
 
         $cookie = $this->getCookie($response);
 
@@ -61,7 +62,7 @@ final class SessionMiddlewareTest extends TestCase
                 file_get_contents(__DIR__ . '/../../keys/public_key.pem'),
                 200
             )
-            ->__invoke(new ServerRequest(), new Response(), $this->writingMiddleware());
+            ->process(new ServerRequest(), $this->writingMiddleware());
 
         $cookie = $this->getCookie($response);
 
@@ -93,7 +94,7 @@ final class SessionMiddlewareTest extends TestCase
     public function testInjectsSessionInResponseCookies(SessionMiddleware $middleware) : void
     {
         $initialResponse = new Response();
-        $response = $middleware(new ServerRequest(), $initialResponse, $this->writingMiddleware());
+        $response = $middleware->process(new ServerRequest(), $this->writingMiddleware());
 
         self::assertNotSame($initialResponse, $response);
         self::assertEmpty($this->getCookie($response, 'non-existing')->getValue());
@@ -107,8 +108,8 @@ final class SessionMiddlewareTest extends TestCase
     {
         $sessionValue = uniqid('', true);
 
-        $checkingMiddleware = $this->fakeMiddleware(
-            function (ServerRequestInterface $request, ResponseInterface $response) use ($sessionValue) {
+        $checkingMiddleware = $this->fakeDelegate(
+            function (ServerRequestInterface $request) use ($sessionValue) {
                 /* @var $session SessionInterface */
                 $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
@@ -123,21 +124,18 @@ final class SessionMiddlewareTest extends TestCase
                     . 'non-modified session containers are not to be re-serialized into a token'
                 );
 
-                return $response;
+                return new Response();
             }
         );
 
-        $firstResponse = $middleware(new ServerRequest(), new Response(), $this->writingMiddleware($sessionValue));
+        $firstResponse = $middleware->process(new ServerRequest(), $this->writingMiddleware($sessionValue));
 
-        $initialResponse = new Response();
-
-        $response = $middleware(
+        $response = $middleware->process(
             $this->requestWithResponseCookies($firstResponse),
-            $initialResponse,
             $checkingMiddleware
         );
 
-        self::assertNotSame($initialResponse, $response);
+        self::assertNotSame($response, $firstResponse);
     }
 
     /**
@@ -236,7 +234,9 @@ final class SessionMiddlewareTest extends TestCase
                     ->getToken()
             ]);
 
-        $cookie = $this->getCookie($middleware->__invoke($requestWithTokenIssuedInThePast, new Response()));
+        $cookie = $this->getCookie($middleware->process($requestWithTokenIssuedInThePast, $this->fakeDelegate(function () {
+            return new Response();
+        })));
 
         $token = (new Parser())->parse($cookie->getValue());
 
@@ -251,10 +251,10 @@ final class SessionMiddlewareTest extends TestCase
         $this->ensureSameResponse(
             $middleware,
             $this->requestWithResponseCookies(
-                $middleware(new ServerRequest(), new Response(), $this->writingMiddleware())
+                $middleware->process(new ServerRequest(), $this->writingMiddleware())
             ),
-            $this->fakeMiddleware(
-                function (ServerRequestInterface $request, ResponseInterface $response) {
+            $this->fakeDelegate(
+                function (ServerRequestInterface $request) {
                     /* @var $session SessionInterface */
                     $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
@@ -263,7 +263,7 @@ final class SessionMiddlewareTest extends TestCase
 
                     self::assertFalse($session->hasChanged());
 
-                    return $response;
+                    return new Response();
                 }
             )
         );
@@ -277,16 +277,16 @@ final class SessionMiddlewareTest extends TestCase
         $this->ensureClearsSessionCookie(
             $middleware,
             $this->requestWithResponseCookies(
-                $middleware(new ServerRequest(), new Response(), $this->writingMiddleware())
+                $middleware->process(new ServerRequest(), $this->writingMiddleware())
             ),
-            $this->fakeMiddleware(
-                function (ServerRequestInterface $request, ResponseInterface $response) {
+            $this->fakeDelegate(
+                function (ServerRequestInterface $request) {
                     /* @var $session SessionInterface */
                     $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
                     $session->clear();
 
-                    return $response;
+                    return new Response();
                 }
             )
         );
@@ -319,7 +319,7 @@ final class SessionMiddlewareTest extends TestCase
         $this->ensureSameResponse(
             $middleware,
             $this->requestWithResponseCookies(
-                $middleware(new ServerRequest(), new Response(), $this->writingMiddleware())
+                $middleware->process(new ServerRequest(), $this->writingMiddleware())
             ),
             $this->emptyValidationMiddleware()
         );
@@ -346,10 +346,8 @@ final class SessionMiddlewareTest extends TestCase
             123
         );
 
-        $initialResponse = new Response();
-        $response = $middleware(new ServerRequest(), $initialResponse, $this->writingMiddleware());
+        $response = $middleware->process(new ServerRequest(), $this->writingMiddleware());
 
-        self::assertNotSame($initialResponse, $response);
         self::assertNull($this->getCookie($response)->getValue());
 
         $tokenCookie = $this->getCookie($response, 'a-different-cookie-name');
@@ -383,16 +381,15 @@ final class SessionMiddlewareTest extends TestCase
                     ->getToken()
             ]);
 
-        $middleware(
+        $middleware->process(
             $request,
-            new Response(),
-            $this->fakeMiddleware(function (ServerRequestInterface $request, ResponseInterface $response) {
+            $this->fakeDelegate(function (ServerRequestInterface $request) {
                 self::assertInstanceOf(
                     SessionInterface::class,
                     $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE)
                 );
 
-                return $response;
+                return new Response();
             })
         );
     }
@@ -422,7 +419,10 @@ final class SessionMiddlewareTest extends TestCase
             ]);
 
         $initialResponse = new Response();
-        $response = $middleware($expiringToken, $initialResponse);
+
+        $response = $middleware->process($expiringToken, $this->fakeDelegate(function () use ($initialResponse) {
+            return $initialResponse;
+        }));
 
         self::assertNotSame($initialResponse, $response);
 
@@ -492,7 +492,7 @@ final class SessionMiddlewareTest extends TestCase
             $this
                 ->getCookie(
                     SessionMiddleware::fromSymmetricKeyDefaults('not relevant', 100)
-                        ->__invoke(new ServerRequest(), new Response(), $this->writingMiddleware())
+                        ->process(new ServerRequest(), $this->writingMiddleware())
                 )
                 ->getPath()
         );
@@ -516,48 +516,51 @@ final class SessionMiddlewareTest extends TestCase
                             file_get_contents(__DIR__ . '/../../keys/public_key.pem'),
                             200
                         )
-                        ->__invoke(new ServerRequest(), new Response(), $this->writingMiddleware())
+                        ->process(new ServerRequest(), $this->writingMiddleware())
                 )
                 ->getPath()
         );
     }
 
-    /**
-     * @param SessionMiddleware $middleware
-     * @param ServerRequestInterface $request
-     * @param callable $next
-     *
-     * @return ResponseInterface
-     */
     private function ensureSameResponse(
         SessionMiddleware $middleware,
         ServerRequestInterface $request,
-        callable $next = null
+        RequestHandlerInterface $next = null
     ) : ResponseInterface {
         $initialResponse = new Response();
-        $response = $middleware($request, $initialResponse, $next);
+
+        $handleRequest = $this->createMock(RequestHandlerInterface::class);
+
+        if ($next) {
+            // capturing `$initialResponse` from the `$next` handler
+            $handleRequest
+                ->expects(self::once())
+                ->method('handle')
+                ->willReturnCallback(function (ServerRequestInterface $serverRequest) use ($next, & $initialResponse) {
+                    $initialResponse = $next->handle($serverRequest);
+
+                    return $initialResponse;
+                });
+        } else {
+            $handleRequest
+                ->expects(self::once())
+                ->method('handle')
+                ->willReturn($initialResponse);
+        }
+
+        $response = $middleware->process($request, $handleRequest);
 
         self::assertSame($initialResponse, $response);
 
         return $response;
     }
 
-    /**
-     * @param SessionMiddleware $middleware
-     * @param ServerRequestInterface $request
-     * @param callable $next
-     *
-     * @return ResponseInterface
-     */
     private function ensureClearsSessionCookie(
         SessionMiddleware $middleware,
         ServerRequestInterface $request,
-        callable $next = null
+        RequestHandlerInterface $next
     ) : ResponseInterface {
-        $initialResponse = new Response();
-        $response = $middleware($request, $initialResponse, $next);
-
-        self::assertNotSame($initialResponse, $response);
+        $response = $middleware->process($request, $next);
 
         $cookie = $this->getCookie($response);
 
@@ -584,59 +587,43 @@ final class SessionMiddlewareTest extends TestCase
             ->getToken();
     }
 
-    /**
-     * @return MiddlewareInterface
-     */
-    private function emptyValidationMiddleware() : MiddlewareInterface
+    private function emptyValidationMiddleware() : RequestHandlerInterface
     {
-        return $this->fakeMiddleware(
-            function (ServerRequestInterface $request, ResponseInterface $response) {
+        return $this->fakeDelegate(
+            function (ServerRequestInterface $request) {
                 /* @var $session SessionInterface */
                 $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
 
                 self::assertInstanceOf(SessionInterface::class, $session);
                 self::assertTrue($session->isEmpty());
 
-                return $response;
+                return new Response();
             }
         );
     }
 
-    /**
-     * @param string $value
-     *
-     * @return MiddlewareInterface
-     */
-    private function writingMiddleware(string $value = 'bar') : MiddlewareInterface
+    private function writingMiddleware(string $value = 'bar') : RequestHandlerInterface
     {
-        return $this->fakeMiddleware(
-            function (ServerRequestInterface $request, ResponseInterface $response) use ($value) {
+        return $this->fakeDelegate(
+            function (ServerRequestInterface $request) use ($value) {
                 /* @var $session SessionInterface */
                 $session = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
                 $session->set('foo', $value);
 
-                return $response;
+                return new Response();
             }
         );
     }
 
-    /**
-     * @param callable $callback
-     *
-     * @return MiddlewareInterface
-     */
-    private function fakeMiddleware(callable $callback) : MiddlewareInterface
+    private function fakeDelegate(callable $callback) : RequestHandlerInterface
     {
-        $middleware = $this->createMock(MiddlewareInterface::class);
+        $middleware = $this->createMock(RequestHandlerInterface::class);
 
-        $middleware->expects($this->once())
-           ->method('__invoke')
+        $middleware
+            ->expects(self::once())
+           ->method('handle')
            ->willReturnCallback($callback)
-           ->with(
-               self::isInstanceOf(ServerRequestInterface::class),
-               self::isInstanceOf(ResponseInterface::class),
-               self::logicalOr(self::isNull(), self::isType('callable'))
-           );
+           ->with(self::isInstanceOf(RequestInterface::class));
 
         return $middleware;
     }

--- a/test/StoragelessTest/Session/DefaultSessionDataTest.php
+++ b/test/StoragelessTest/Session/DefaultSessionDataTest.php
@@ -20,13 +20,13 @@ declare(strict_types=1);
 
 namespace PSR7SessionsTest\Storageless\Session;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use PSR7Sessions\Storageless\Session\DefaultSessionData;
 
 /**
  * @covers \PSR7Sessions\Storageless\Session\DefaultSessionData
  */
-final class DefaultSessionDataTest extends PHPUnit_Framework_TestCase
+final class DefaultSessionDataTest extends TestCase
 {
     public function testFromFromTokenDataBuildsADataContainer() : void
     {

--- a/test/StoragelessTest/Session/LazySessionTest.php
+++ b/test/StoragelessTest/Session/LazySessionTest.php
@@ -20,14 +20,14 @@ declare(strict_types=1);
 
 namespace PSR7SessionsTest\Storageless\Session;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use PSR7Sessions\Storageless\Session\LazySession;
 use PSR7Sessions\Storageless\Session\SessionInterface;
 
 /**
  * @covers \PSR7Sessions\Storageless\Session\LazySession
  */
-final class LazySessionTest extends PHPUnit_Framework_TestCase
+final class LazySessionTest extends TestCase
 {
     /**
      * @var SessionInterface|\PHPUnit_Framework_MockObject_MockObject


### PR DESCRIPTION
This patch is a breaking change targeting `4.0.0`. The `PSR7Sessions\Storageless\Http\SessionMiddleware` is now PSR-15 compliant, as it implements `Psr\Http\Server\MiddlewareInterface`

This also simplifies some quite squishy type issues around nullability of the `next` middleware.