### PR TITLE
Replace humbug with infection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ vendor
 composer.lock
 composer.phar
 clover.xml
-humbuglog.txt
-humbuglog.json
+infection.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_script:
 script:
   - ./vendor/bin/phpunit $PHPUNIT_FLAGS
   - php examples/index.php > /dev/null
-  - if php -i |grep -qE xdebug; then ./vendor/bin/humbug; fi
+  - if php -i |grep -qE xdebug; then ./vendor/bin/infection --threads=4 --log-verbosity=none; fi
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "phpunit/phpunit":              "^6.5.5",
         "zendframework/zend-diactoros": "^1.7.0",
-        "humbug/humbug":                "^1.0.0-rc.0"
+        "infection/infection":          "^0.9.2"
     },
     "replace": {
         "ocramius/psr7-session": "self.version"

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -6,7 +6,6 @@
     },
     "timeout": 10,
     "logs": {
-        "text": "humbuglog.txt",
-        "json": "humbuglog.json"
+        "text": "infection.txt"
     }
 }


### PR DESCRIPTION
Humbug has been deprecated in favor of infection.

I also took the liberty to add an empty line at the end of `.gitignore` and `infection.json.dist`