### PR TITLE
zend-expressive-session-integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 composer.phar
 clover.xml
 infectionlog.txt
+.phpcs-cache

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Packagist](https://img.shields.io/packagist/v/psr7-sessions/storageless.svg)](https://packagist.org/packages/psr7-sessions/storageless)
 [![Packagist](https://img.shields.io/packagist/vpre/psr7-sessions/storageless.svg)](https://packagist.org/packages/psr7-sessions/storageless)
 
-**PSR7Session** is a [PSR-7](http://www.php-fig.org/psr/psr-7/) and 
+**PSR7Session** is a [PSR-7](http://www.php-fig.org/psr/psr-7/) and
 [PSR-15](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-15-request-handlers.md)
 compatible [middleware](https://mwop.net/blog/2015-01-08-on-http-middleware-and-psr-7.html) that enables
 session without I/O usage in PSR-7 based applications.
@@ -21,7 +21,7 @@ composer require psr7-sessions/storageless
 
 ### Usage
 
-You can use the `PSR7Sessions\Storageless\Http\SessionMiddleware` in any 
+You can use the `PSR7Sessions\Storageless\Http\SessionMiddleware` in any
 [PSR-15](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-15-request-handlers.md)
 compatible middleware.
 
@@ -88,7 +88,7 @@ identifier to a visiting user-agent.
 This is all fair and nice, except for:
 
  * relying on the `$_SESSION` superglobal
- * relying on the shutdown handlers in order to "commit" sessions to the 
+ * relying on the shutdown handlers in order to "commit" sessions to the
    storage
  * having a huge limitation of number of active users (due to storage)
  * having a lot of I/O due to storage
@@ -131,7 +131,7 @@ tokens.
 ### Advantages
 
  * no storage required
- * no sticky sessions required (any server having a copy of the private or 
+ * no sticky sessions required (any server having a copy of the private or
    public keys can generate sessions or consume them)
  * can transmit cleartext information to the client, allowing it to share
    some information with the server (a standard example is about sharing the
@@ -153,6 +153,10 @@ Please refer to the [configuration documentation](docs/configuration.md).
 ### Known limitations
 
 Please refer to the [limitations documentation](docs/limitations.md).
+
+### Zend Expressive session integration
+
+Please refer to the [zend-expressive-session documentation](docs/zend-expressive-session.md).
 
 ### Contributing
 

--- a/composer.json
+++ b/composer.json
@@ -38,10 +38,17 @@
         "phpstan/phpstan-phpunit":      "^0.10",
         "phpstan/phpstan-strict-rules": "^0.10.1",
         "squizlabs/php_codesniffer":    "^3.3.1",
-        "doctrine/coding-standard":     "^4.0.0"
+        "doctrine/coding-standard":     "^4.0.0",
+        "zendframework/zend-expressive-session": "^1.2.1"
     },
     "replace": {
         "ocramius/psr7-session": "self.version"
+    },
+    "conflict": {
+        "zendframework/zend-expressive-session": "<1.2,>2.0"
+    },
+    "suggest": {
+        "zendframework/zend-expressive-session": "Integrates storageless with dependencies on zend-expressive-session"
     },
     "autoload": {
         "psr-4": {
@@ -55,7 +62,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0.x-dev"
+            "dev-master": "5.1.x-dev"
         }
     }
 }

--- a/docs/zend-expressive-session.md
+++ b/docs/zend-expressive-session.md
@@ -1,0 +1,36 @@
+## Zend Expressive Session Integration
+
+This integration allows you to use storageless as an implementation for [zend-expressive-session][1]
+
+#### Symmetric key
+
+```php
+use PSR7Sessions\Storageless\Http\SessionMiddleware as PSR7SessionMiddleware;
+use PSR7Sessions\Storageless\Session\Zend\SessionPersistence;
+use Zend\Expressive\Session\SessionMiddleware;
+
+$app = \Zend\Expressive\AppFactory::create();
+$app->pipe(PSR7SessionMiddleware::fromSymmetricKeyDefaults(
+    'OpcMuKmoxkhzW0Y1iESpjWwL/D3UBdDauJOe742BJ5Q=',
+    1200
+));
+$app->pipe(new SessionMiddleware(new SessionPersistence()));
+```
+
+#### Asymmetric key
+
+```php
+use PSR7Sessions\Storageless\Http\SessionMiddleware as PSR7SessionMiddleware;
+use PSR7Sessions\Storageless\Session\Zend\SessionPersistence;
+use Zend\Expressive\Session\SessionMiddleware;
+
+$app = \Zend\Expressive\AppFactory::create();
+$app->pipe(PSR7SessionMiddleware::fromSymmetricKeyDefaults(
+    file_get_contents('/path/to/private_key.pem'),
+    file_get_contents('/path/to/public_key.pem'),
+    1200
+));
+$app->pipe(new SessionMiddleware(new SessionPersistence()));
+```
+
+[1]: https://github.com/zendframework/zend-expressive-session

--- a/src/Storageless/Session/Zend/SessionAdapter.php
+++ b/src/Storageless/Session/Zend/SessionAdapter.php
@@ -1,0 +1,100 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+declare(strict_types=1);
+
+namespace PSR7Sessions\Storageless\Session\Zend;
+
+use Lcobucci\Clock\Clock;
+use Lcobucci\Clock\SystemClock;
+use PSR7Sessions\Storageless\Session\SessionInterface;
+use Zend\Expressive\Session\SessionInterface as ZendSessionInterface;
+
+final class SessionAdapter implements ZendSessionInterface
+{
+    private const SESSION_REGENERATED_NAME = '_regenerated';
+
+    /** @var SessionInterface */
+    private $session;
+
+    /** @var Clock */
+    private $clock;
+
+    public function __construct(SessionInterface $session, ?Clock $clock = null)
+    {
+        $this->session = $session;
+        $this->clock   = $clock ?? new SystemClock();
+    }
+
+    /**
+     * @return array
+     */
+    public function toArray() : array
+    {
+        return (array) $this->session->jsonSerialize();
+    }
+
+    /** {@inheritDoc} */
+    public function get(string $name, $default = null)
+    {
+        return $this->session->get($name, $default);
+    }
+
+    public function has(string $name) : bool
+    {
+        return $this->session->has($name);
+    }
+
+    /** {@inheritDoc} */
+    public function set(string $name, $value) : void
+    {
+        $this->session->set($name, $value);
+    }
+
+    public function unset(string $name) : void
+    {
+        $this->session->remove($name);
+    }
+
+    public function clear() : void
+    {
+        $this->session->clear();
+    }
+
+    public function hasChanged() : bool
+    {
+        return $this->session->hasChanged();
+    }
+
+    public function regenerate() : ZendSessionInterface
+    {
+        $this->session->set(self::SESSION_REGENERATED_NAME, $this->timestamp());
+
+        return $this;
+    }
+
+    public function isRegenerated() : bool
+    {
+        return $this->session->has(self::SESSION_REGENERATED_NAME);
+    }
+
+    private function timestamp() : int
+    {
+        return $this->clock->now()->getTimestamp();
+    }
+}

--- a/src/Storageless/Session/Zend/SessionPersistence.php
+++ b/src/Storageless/Session/Zend/SessionPersistence.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+declare(strict_types=1);
+
+namespace PSR7Sessions\Storageless\Session\Zend;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use PSR7Sessions\Storageless\Http\SessionMiddleware;
+use PSR7Sessions\Storageless\Session\SessionInterface;
+use UnexpectedValueException;
+use Zend\Expressive\Session\SessionInterface as ZendSessionInterface;
+use Zend\Expressive\Session\SessionPersistenceInterface as ZendSessionPersistenceInterface;
+use function sprintf;
+
+final class SessionPersistence implements ZendSessionPersistenceInterface
+{
+    public function initializeSessionFromRequest(ServerRequestInterface $request) : ZendSessionInterface
+    {
+        /** @var SessionInterface|null $storagelessSession */
+        $storagelessSession = $request->getAttribute(SessionMiddleware::SESSION_ATTRIBUTE);
+        if (! $storagelessSession instanceof SessionInterface) {
+            throw new UnexpectedValueException(
+                sprintf(
+                    'Please add this following middleware "%s" before execute this method "%s"',
+                    SessionMiddleware::class,
+                    __METHOD__
+                )
+            );
+        }
+
+        return new SessionAdapter($storagelessSession);
+    }
+
+    public function persistSession(ZendSessionInterface $session, ResponseInterface $response) : ResponseInterface
+    {
+        return $response;
+    }
+}

--- a/test/StoragelessTest/Session/Zend/SessionAdapterTest.php
+++ b/test/StoragelessTest/Session/Zend/SessionAdapterTest.php
@@ -1,0 +1,135 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+declare(strict_types=1);
+
+namespace PSR7SessionsTest\Storageless\Session\Zend;
+
+use DateTimeImmutable;
+use Lcobucci\Clock\FrozenClock;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use PSR7Sessions\Storageless\Session\SessionInterface;
+use PSR7Sessions\Storageless\Session\Zend\SessionAdapter;
+use stdClass;
+
+/**
+ * @covers \PSR7Sessions\Storageless\Session\Zend\SessionAdapter
+ */
+final class SessionAdapterTest extends TestCase
+{
+    public function testToArray() : void
+    {
+        $object      = new stdClass();
+        $object->key = 'value';
+
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::once())->method('jsonSerialize')->with()->willReturn($object);
+
+        $sessionAdapter = new SessionAdapter($session);
+
+        self::assertSame(['key' => 'value'], $sessionAdapter->toArray());
+    }
+
+    public function testGet() : void
+    {
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::once())->method('get')->with('key', null)->willReturn('value');
+
+        $sessionAdapter = new SessionAdapter($session);
+
+        self::assertSame('value', $sessionAdapter->get('key'));
+    }
+
+    public function testHas() : void
+    {
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::once())->method('has')->with('key')->willReturn(true);
+
+        $sessionAdapter = new SessionAdapter($session);
+
+        self::assertTrue($sessionAdapter->has('key'));
+    }
+
+    public function testSet() : void
+    {
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::once())->method('set')->with('key', 'value');
+
+        $sessionAdapter = new SessionAdapter($session);
+        $sessionAdapter->set('key', 'value');
+    }
+
+    public function testUnset() : void
+    {
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::once())->method('remove')->with('key');
+
+        $sessionAdapter = new SessionAdapter($session);
+        $sessionAdapter->unset('key');
+    }
+
+    public function testClear() : void
+    {
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::once())->method('clear')->with();
+
+        $sessionAdapter = new SessionAdapter($session);
+        $sessionAdapter->clear();
+    }
+
+    public function testHasChanged() : void
+    {
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::once())->method('hasChanged')->with()->willReturn(true);
+
+        $sessionAdapter = new SessionAdapter($session);
+
+        self::assertTrue($sessionAdapter->hasChanged());
+    }
+
+    public function testRegenerate() : void
+    {
+        $clock = new FrozenClock(new DateTimeImmutable('2019-01-01T00:00:00+00:00'));
+
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::once())->method('set')->with('_regenerated', $clock->now()->getTimestamp());
+
+        $sessionAdapter = new SessionAdapter($session, $clock);
+        $sessionAdapter->regenerate();
+    }
+
+    public function testIsRegenerated() : void
+    {
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::once())->method('has')->with('_regenerated')->willReturn(true);
+
+        $sessionAdapter = new SessionAdapter($session);
+
+        self::assertTrue($sessionAdapter->isRegenerated());
+    }
+}

--- a/test/StoragelessTest/Session/Zend/SessionPersistenceTest.php
+++ b/test/StoragelessTest/Session/Zend/SessionPersistenceTest.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license.
+ */
+
+declare(strict_types=1);
+
+namespace PSR7SessionsTest\Storageless\Session\Zend;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use PSR7Sessions\Storageless\Http\SessionMiddleware;
+use PSR7Sessions\Storageless\Session\SessionInterface;
+use PSR7Sessions\Storageless\Session\Zend\SessionPersistence;
+use UnexpectedValueException;
+use Zend\Expressive\Session\SessionInterface as ZendSessionInterface;
+use function sprintf;
+
+/**
+ * @covers \PSR7Sessions\Storageless\Session\Zend\SessionPersistence
+ */
+final class SessionPersistenceTest extends TestCase
+{
+    public function testInitializeSessionFromRequestWithMissingPsr7SessionAttribute() : void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->expectExceptionMessage(sprintf(
+            'Please add this following middleware "%s" before execute this method "%s::initializeSessionFromRequest"',
+            SessionMiddleware::class,
+            SessionPersistence::class
+        ));
+
+        /** @var ServerRequestInterface|MockObject $request */
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $request
+            ->expects(self::once())
+            ->method('getAttribute')
+            ->with(SessionMiddleware::SESSION_ATTRIBUTE, null)
+            ->willReturn(null);
+
+        $persistence = new SessionPersistence();
+        $persistence->initializeSessionFromRequest($request);
+    }
+
+    public function testInitializeSessionFromRequestWithPsr7SessionAttribute() : void
+    {
+        /** @var SessionInterface|MockObject $session */
+        $session = $this->getMockBuilder(SessionInterface::class)->getMock();
+        $session->expects(self::never())->method(self::anything());
+
+        /** @var ServerRequestInterface|MockObject $request */
+        $request = $this->getMockBuilder(ServerRequestInterface::class)->getMock();
+        $request
+            ->expects(self::once())
+            ->method('getAttribute')
+            ->with(SessionMiddleware::SESSION_ATTRIBUTE, null)
+            ->willReturn($session);
+
+        $persistence = new SessionPersistence();
+        $persistence->initializeSessionFromRequest($request);
+    }
+
+    public function testPersistSession() : void
+    {
+        /** @var ZendSessionInterface|MockObject $zendSession */
+        $zendSession = $this->getMockBuilder(ZendSessionInterface::class)->getMock();
+        $zendSession->expects(self::never())->method(self::anything());
+
+        /** @var ResponseInterface|MockObject $response */
+        $response = $this->getMockBuilder(ResponseInterface::class)->getMock();
+        $response->expects(self::never())->method(self::anything());
+
+        $persistence = new SessionPersistence();
+
+        self::assertSame($response, $persistence->persistSession($zendSession, $response));
+    }
+}


### PR DESCRIPTION
@Ocramius can you help me to fix this one?

```
38 | ERROR | @return annotation of method \PSR7Sessions\Storageless\Session\Zend\SessionAdapter::toArray() does not
    |       | specify type hint for items of its traversable return value.
```