### PR TITLE
Set "__Secure-" Cookie Prefix by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,7 +71,7 @@ If you want to fine-tune more settings of `PSR7Session`, then simply use the
 use PSR7Sessions\Storageless\Http\SessionMiddleware;
 
 // a blueprint of the cookie that `PSR7Session` should use to generate
-// and read cookies:
+// and read cookies, be careful to secure it, see defaults below:
 $cookieBlueprint   = \Dflydev\FigCookies\SetCookie::create('cookie-name');
 $sessionMiddleware = new SessionMiddleware(
     $signer, // an \Lcobucci\JWT\Signer
@@ -85,16 +85,19 @@ $sessionMiddleware = new SessionMiddleware(
 );
 ```
 
-It is recommended not to use this setup
+It is recommended not to use this setup.
 
 ### Defaults
 
-By default, sessions generated via the `SessionMiddleware` use following parameters:
+By default, sessions generated via the `SessionMiddleware` factory methods use following parameters:
 
- * `"__Secure-slsession"` is the name of the cookie where the session is stored
- * `"__Secure-slsession"` cookie is configured as [`HttpOnly`](https://www.owasp.org/index.php/HttpOnly)
- * `"__Secure-slsession"` cookie is configured as [`secure`](https://www.owasp.org/index.php/SecureFlag)
- * The `"__Secure-slsession"` cookie will contain a [JWT token](http://jwt.io/)
+ * `"__Secure-slsession"` is the name of the cookie where the session is stored, [`__Secure-`](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes)
+ prefix is intentional
+ * `"__Secure-slsession"` cookie is configured as [`Secure`](https://tools.ietf.org/html/rfc6265#section-4.1.2.5)
+ * `"__Secure-slsession"` cookie is configured as [`HttpOnly`](https://tools.ietf.org/html/rfc6265#section-4.1.2.6)
+ * `"__Secure-slsession"` cookie is configured as [`SameSite=Lax`](https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site)
+ * `"__Secure-slsession"` cookie is configured as [`path=/`](https://github.com/psr7-sessions/storageless/pull/46)
+ * The `"__Secure-slsession"` cookie will contain a [JWT token](https://jwt.io/)
  * The JWT token in the `"__Secure-slsession"` is signed, but **unencrypted**
  * The JWT token in the `"__Secure-slsession"` has an [`iat` claim](https://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#rfc.section.4.1.6)
  * The session is re-generated only after `60` seconds, and **not** at every user-agent interaction

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,10 +91,10 @@ It is recommended not to use this setup
 
 By default, sessions generated via the `SessionMiddleware` use following parameters:
 
- * `"slsession"` is the name of the cookie where the session is stored
- * `"slsession"` cookie is configured as [`HttpOnly`](https://www.owasp.org/index.php/HttpOnly)
- * `"slsession"` cookie is configured as [`secure`](https://www.owasp.org/index.php/SecureFlag)
- * The `"slsession"` cookie will contain a [JWT token](http://jwt.io/)
- * The JWT token in the `"slsession"` is signed, but **unencrypted**
- * The JWT token in the `"slsession"` has an [`iat` claim](https://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#rfc.section.4.1.6)
+ * `"__Secure-slsession"` is the name of the cookie where the session is stored
+ * `"__Secure-slsession"` cookie is configured as [`HttpOnly`](https://www.owasp.org/index.php/HttpOnly)
+ * `"__Secure-slsession"` cookie is configured as [`secure`](https://www.owasp.org/index.php/SecureFlag)
+ * The `"__Secure-slsession"` cookie will contain a [JWT token](http://jwt.io/)
+ * The JWT token in the `"__Secure-slsession"` is signed, but **unencrypted**
+ * The JWT token in the `"__Secure-slsession"` has an [`iat` claim](https://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#rfc.section.4.1.6)
  * The session is re-generated only after `60` seconds, and **not** at every user-agent interaction

--- a/src/Storageless/Http/SessionMiddleware.php
+++ b/src/Storageless/Http/SessionMiddleware.php
@@ -47,7 +47,7 @@ final class SessionMiddleware implements MiddlewareInterface
     public const ISSUED_AT_CLAIM      = 'iat';
     public const SESSION_CLAIM        = 'session-data';
     public const SESSION_ATTRIBUTE    = 'session';
-    public const DEFAULT_COOKIE       = 'slsession';
+    public const DEFAULT_COOKIE       = '__Secure-slsession';
     public const DEFAULT_REFRESH_TIME = 60;
 
     private Signer $signer;

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -52,6 +52,12 @@ use function uniqid;
 final class SessionMiddlewareTest extends TestCase
 {
     /**
+     * @see https://tools.ietf.org/html/rfc6265#section-4.1.2.5 for Secure flag
+     * @see https://tools.ietf.org/html/rfc6265#section-4.1.2.6 for HttpOnly flag
+     * @see https://github.com/psr7-sessions/storageless/pull/46 for / path
+     * @see https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site for SameSite flag
+     * @see https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes for __Secure- prefix
+     *
      * @dataProvider defaultMiddlewaresProvider
      * @group #46
      */

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -628,7 +628,7 @@ final class SessionMiddlewareTest extends TestCase
         $cookie->mutated = true;
 
         self::assertStringStartsWith(
-            'slsession=',
+            '__Secure-slsession=',
             $middleware
                 ->process(new ServerRequest(), $this->writingMiddleware())
                 ->getHeaderLine('Set-Cookie')


### PR DESCRIPTION
Not to be confused with `Secure` flag:

* `Secure` flag (already implemented) means do not **send** the cookie to insecure channel
* `__Secure-` prefix means do not **accept** the cookie from insecure channel

References:

1. https://scotthelme.co.uk/tough-cookies/
1. https://tools.ietf.org/html/draft-ietf-httpbis-cookie-prefixes-00

`__Host-` prefix is much more restrictive: cannot be implemented by default, but we could suggest in the doc to use it