### PR TITLE
Migrate away from deprecated `lcobucci/jwt`'s `LocalFileReference` class

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,12 +29,12 @@ You can set up symmetric key based signatures via the
 `PSR7Sessions::fromAsymmetricKeyDefaults` named constructor:
 
 ```php
-use Lcobucci\JWT\Signer\Key\LocalFileReference;
+use Lcobucci\JWT\Signer\Key\InMemory;
 use PSR7Sessions\Storageless\Http\SessionMiddleware;
 
 $sessionMiddleware = SessionMiddleware::fromRsaAsymmetricKeyDefaults(
-    LocalFileReference::file('/path/to/private_key.pem'),
-    LocalFileReference::file('/path/to/public_key.pem'),
+    InMemory::file('/path/to/private_key.pem'),
+    InMemory::file('/path/to/public_key.pem'),
     1200 // session lifetime, in seconds
 );
 ```

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -625,8 +625,8 @@ final class SessionMiddlewareTest extends TestCase
             'from-asymmetric' => [
                 static function (): SessionMiddleware {
                     return SessionMiddleware::fromRsaAsymmetricKeyDefaults(
-                        Signer\Key\LocalFileReference::file(__DIR__ . '/../../keys/private_key.pem'),
-                        Signer\Key\LocalFileReference::file(__DIR__ . '/../../keys/public_key.pem'),
+                        Signer\Key\InMemory::file(__DIR__ . '/../../keys/private_key.pem'),
+                        Signer\Key\InMemory::file(__DIR__ . '/../../keys/public_key.pem'),
                         200
                     );
                 },


### PR DESCRIPTION
That class has been deprecated due to a potential security issue and we shouldn't rely on it.

See: https://github.com/lcobucci/jwt/security/advisories/GHSA-7322-jrq4-x5hf