### PR TITLE
Rename `expirationTime`/`lifetime` to what it really is: an idle timeout

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ use PSR7Sessions\Storageless\Http\SessionMiddleware;
 
 $sessionMiddleware = SessionMiddleware::fromSymmetricKeyDefaults(
     InMemory::base64Encoded('OpcMuKmoxkhzW0Y1iESpjWwL/D3UBdDauJOe742BJ5Q='), // replace this with a key of your own (see below)
-    1200 // session lifetime, in seconds
+    1200 // session idle timeout, in seconds
 );
 ```
 
@@ -35,7 +35,7 @@ use PSR7Sessions\Storageless\Http\SessionMiddleware;
 $sessionMiddleware = SessionMiddleware::fromRsaAsymmetricKeyDefaults(
     InMemory::file('/path/to/private_key.pem'),
     InMemory::file('/path/to/public_key.pem'),
-    1200 // session lifetime, in seconds
+    1200 // session idle timeout, in seconds
 );
 ```
 
@@ -83,7 +83,7 @@ $sessionMiddleware = new SessionMiddleware(
         InMemory::base64Encoded('FW6ELbU3817sflp2XmnCQ3JJTIMihR1RctQu7VQ73Fg=')
     ),
     SessionMiddleware::buildDefaultCookie(),
-    1200, // session lifetime, in seconds
+    1200, // session idle timeout, in seconds
     SystemClock::fromSystemTimezone(),
     60    // session automatic refresh time, in seconds
 );
@@ -137,7 +137,7 @@ return new SessionMiddleware(
         ->withSecure(false)
         ->withHttpOnly(true)
         ->withPath('/'),
-    1200, // session lifetime, in seconds
+    1200, // session idle timeout, in seconds
     SystemClock::fromUTC(),
 );
 ```

--- a/src/Storageless/Http/SessionMiddleware.php
+++ b/src/Storageless/Http/SessionMiddleware.php
@@ -61,7 +61,7 @@ final class SessionMiddleware implements MiddlewareInterface
     public function __construct(
         Configuration $configuration,
         SetCookie $defaultCookie,
-        private int $expirationTime,
+        private int $idleTimeout,
         private Clock $clock,
         private int $refreshTime = self::DEFAULT_REFRESH_TIME,
     ) {
@@ -72,7 +72,7 @@ final class SessionMiddleware implements MiddlewareInterface
     /**
      * This constructor simplifies instantiation when using HTTPS (REQUIRED!) and symmetric key encryption
      */
-    public static function fromSymmetricKeyDefaults(Signer\Key $symmetricKey, int $expirationTime): self
+    public static function fromSymmetricKeyDefaults(Signer\Key $symmetricKey, int $idleTimeout): self
     {
         return new self(
             Configuration::forSymmetricSigner(
@@ -80,7 +80,7 @@ final class SessionMiddleware implements MiddlewareInterface
                 $symmetricKey,
             ),
             self::buildDefaultCookie(),
-            $expirationTime,
+            $idleTimeout,
             new SystemClock(new DateTimeZone(date_default_timezone_get())),
         );
     }
@@ -92,7 +92,7 @@ final class SessionMiddleware implements MiddlewareInterface
     public static function fromRsaAsymmetricKeyDefaults(
         Signer\Key $privateRsaKey,
         Signer\Key $publicRsaKey,
-        int $expirationTime,
+        int $idleTimeout,
     ): self {
         return new self(
             Configuration::forAsymmetricSigner(
@@ -101,7 +101,7 @@ final class SessionMiddleware implements MiddlewareInterface
                 $publicRsaKey,
             ),
             self::buildDefaultCookie(),
-            $expirationTime,
+            $idleTimeout,
             new SystemClock(new DateTimeZone(date_default_timezone_get())),
         );
     }
@@ -222,7 +222,7 @@ final class SessionMiddleware implements MiddlewareInterface
     private function getTokenCookie(SessionInterface $sessionContainer): SetCookie
     {
         $now       = $this->clock->now();
-        $expiresAt = $now->add(new DateInterval(sprintf('PT%sS', $this->expirationTime)));
+        $expiresAt = $now->add(new DateInterval(sprintf('PT%sS', $this->idleTimeout)));
 
         return $this
             ->defaultCookie


### PR DESCRIPTION
Fix https://github.com/psr7-sessions/storageless/issues/553 issue 1