### PR TITLE
Update `lcobucci/jwt` to ^4.3.0 and `lcobucci/clock` to v3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,12 @@
-/test export-ignore
-/tools export-ignore
-/examples export-ignore
-.gitattributes export-ignore
-.gitignore export-ignore
-.scrutinizer.yml export-ignore
-.travis.yml export-ignore
-phpunit.xml.dist
+/.github                export-ignore
+/test                   export-ignore
+/tools                  export-ignore
+/examples               export-ignore
+/.gitattributes         export-ignore
+/.gitignore             export-ignore
+/composer.lock          export-ignore
+/infection.json.dist    export-ignore
+/phpcs.xml.dist         export-ignore
+/psalm.xml              export-ignore
+/phpunit.xml.dist       export-ignore
+/renovate.json          export-ignore

--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,8 @@
         "php":                             "~8.1.0 || ~8.2.0",
         "ext-json":                        "*",
         "dflydev/fig-cookies":             "^3.0.0",
-        "lcobucci/jwt":                    "^4.2.1",
-        "lcobucci/clock":                  "^2.3.0",
+        "lcobucci/jwt":                    "^4.3.0",
+        "lcobucci/clock":                  "^3.0.0",
         "psr/http-message":                "^1.0.1",
         "psr/http-server-handler":         "^1.0.1",
         "psr/http-server-middleware":      "^1.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8eb9698b0a75d6b051f2d5e012a5888c",
+    "content-hash": "9f019d7270983f4ec31020b2dd78742a",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -70,21 +70,21 @@
         },
         {
             "name": "lcobucci/clock",
-            "version": "2.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/clock.git",
-                "reference": "c7aadcd6fd97ed9e199114269c0be3f335e38876"
+                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/clock/zipball/c7aadcd6fd97ed9e199114269c0be3f335e38876",
-                "reference": "c7aadcd6fd97ed9e199114269c0be3f335e38876",
+                "url": "https://api.github.com/repos/lcobucci/clock/zipball/039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
+                "reference": "039ef98c6b57b101d10bd11d8fdfda12cbd996dc",
                 "shasum": ""
             },
             "require": {
                 "php": "~8.1.0 || ~8.2.0",
-                "stella-maris/clock": "^0.1.7"
+                "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -118,7 +118,7 @@
             "description": "Yet another clock abstraction",
             "support": {
                 "issues": "https://github.com/lcobucci/clock/issues",
-                "source": "https://github.com/lcobucci/clock/tree/2.3.0"
+                "source": "https://github.com/lcobucci/clock/tree/3.0.0"
             },
             "funding": [
                 {
@@ -130,20 +130,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-12-19T14:38:11+00:00"
+            "time": "2022-12-19T15:00:24+00:00"
         },
         {
             "name": "lcobucci/jwt",
-            "version": "4.2.1",
+            "version": "4.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "72ac6d807ee51a70ad376ee03a2387e8646e10f3"
+                "reference": "4d7de2fe0d51a96418c0d04004986e410e87f6b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/72ac6d807ee51a70ad376ee03a2387e8646e10f3",
-                "reference": "72ac6d807ee51a70ad376ee03a2387e8646e10f3",
+                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/4d7de2fe0d51a96418c0d04004986e410e87f6b4",
+                "reference": "4d7de2fe0d51a96418c0d04004986e410e87f6b4",
                 "shasum": ""
             },
             "require": {
@@ -152,7 +152,7 @@
                 "ext-mbstring": "*",
                 "ext-openssl": "*",
                 "ext-sodium": "*",
-                "lcobucci/clock": "^2.0",
+                "lcobucci/clock": "^2.0 || ^3.0",
                 "php": "^7.4 || ^8.0"
             },
             "require-dev": {
@@ -192,7 +192,7 @@
             ],
             "support": {
                 "issues": "https://github.com/lcobucci/jwt/issues",
-                "source": "https://github.com/lcobucci/jwt/tree/4.2.1"
+                "source": "https://github.com/lcobucci/jwt/tree/4.3.0"
             },
             "funding": [
                 {
@@ -204,7 +204,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-08-19T23:14:07+00:00"
+            "time": "2023-01-02T13:28:00+00:00"
         },
         {
             "name": "psr/clock",
@@ -420,53 +420,6 @@
                 "source": "https://github.com/php-fig/http-server-middleware/tree/master"
             },
             "time": "2018-10-30T17:12:04+00:00"
-        },
-        {
-            "name": "stella-maris/clock",
-            "version": "0.1.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/stella-maris-solutions/clock.git",
-                "reference": "fa23ce16019289a18bb3446fdecd45befcdd94f8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/stella-maris-solutions/clock/zipball/fa23ce16019289a18bb3446fdecd45befcdd94f8",
-                "reference": "fa23ce16019289a18bb3446fdecd45befcdd94f8",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0|^8.0",
-                "psr/clock": "^1.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "StellaMaris\\Clock\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Andreas Heigl",
-                    "role": "Maintainer"
-                }
-            ],
-            "description": "A pre-release of the proposed PSR-20 Clock-Interface",
-            "homepage": "https://gitlab.com/stella-maris/clock",
-            "keywords": [
-                "clock",
-                "datetime",
-                "point in time",
-                "psr20"
-            ],
-            "support": {
-                "source": "https://github.com/stella-maris-solutions/clock/tree/0.1.7"
-            },
-            "time": "2022-11-25T16:15:06+00:00"
         }
     ],
     "packages-dev": [
@@ -1115,30 +1068,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.4.1",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/10dcfce151b967d20fde1b34ae6640712c3891bc",
-                "reference": "10dcfce151b967d20fde1b34ae6640712c3891bc",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
                 "phpbench/phpbench": "^0.16 || ^1",
                 "phpstan/phpstan": "^1.4",
                 "phpstan/phpstan-phpunit": "^1",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.22"
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -1165,7 +1118,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.4.1"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -1181,7 +1134,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-03-03T08:28:38+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",

--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -236,7 +236,10 @@ final class SessionMiddlewareTest extends TestCase
     {
         $unknownTokenType = $this->createMock(Token::class);
         $fakeParser       = $this->createMock(ParserInterface::class);
-        $configuration    = Configuration::forUnsecuredSigner();
+        $configuration    = Configuration::forSymmetricSigner(
+            new Sha256(),
+            self::makeRandomSymmetricKey(),
+        );
 
         $fakeParser->expects(self::atLeastOnce())
             ->method('parse')
@@ -285,7 +288,10 @@ final class SessionMiddlewareTest extends TestCase
     public function testWillIgnoreUnSignedTokens(callable $middlewareFactory): void
     {
         $middleware    = $middlewareFactory();
-        $configuration = Configuration::forUnsecuredSigner();
+        $configuration = Configuration::forSymmetricSigner(
+            new Sha256(),
+            self::makeRandomSymmetricKey(),
+        );
         $unsignedToken = (new ServerRequest())
             ->withCookieParams([
                 SessionMiddleware::DEFAULT_COOKIE => $configuration->builder()


### PR DESCRIPTION
Replace https://github.com/psr7-sessions/storageless/pull/552 and https://github.com/psr7-sessions/storageless/pull/555 and Fix https://github.com/psr7-sessions/storageless/pull/555 CI failures

I propose myself as a `Collaborator` for this library, so in the future I'll be able to handle such contributions more effectively and autonomously. I'll still ask for review on https://github.com/psr7-sessions/storageless/labels/BC%20break and API upgrades.

Fixes #555 
Fixes #552 