### PR TITLE
tests: remove duplicated test code

### DIFF
--- a/test/StoragelessTest/Http/SessionMiddlewareTest.php
+++ b/test/StoragelessTest/Http/SessionMiddlewareTest.php
@@ -192,13 +192,6 @@ final class SessionMiddlewareTest extends TestCase
             },
         );
 
-        $this->createTokenWithCustomClaim(
-            $middleware,
-            new DateTimeImmutable('-1 day'),
-            new DateTimeImmutable('+1 day'),
-            'not valid session data',
-        );
-
         $middleware->process(
             (new ServerRequest())
                 ->withCookieParams([


### PR DESCRIPTION
Hello,

As I continue to work on this project, I've come across a duplicated code snippet while reviewing the test code. It appears that this redundancy is unnecessary. I believe we can safely remove the duplicate snippet without affecting anything.

Please let me know if you have any concerns or if there's a specific reason for the duplication.

Thank you.