### PR TITLE
[CI] Drop `laminas-continuous-integration-action`, add jobs static Config

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,36 +1,107 @@
-# See https://github.com/laminas/laminas-continuous-integration-action
-# Generates a job matrix based on current dependencies and supported version
-# ranges, then runs all those jobs
-name: "Continuous Integration"
+name: "CI"
 
 on:
   pull_request:
   push:
 
-jobs:
-  matrix:
-    name: Generate job matrix
-    runs-on: ubuntu-latest
-    outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
-    steps:
-      - name: Gather CI configuration
-        id: matrix
-        uses: laminas/laminas-ci-matrix-action@1.27.2
+env:
+  PHP_CURRENT: "8.2"
+  PHP_NEXT: "8.3"
 
-  qa:
-    name: QA Checks
-    needs: [ matrix ]
-    runs-on: ${{ matrix.operatingSystem }}
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(needs.matrix.outputs.matrix) }}
+jobs:
+  composer-json-lint:
+    name: "Lint composer.json"
+    runs-on: "ubuntu-latest"
+
     steps:
-      - name: ${{ matrix.name }}
-        uses: laminas/laminas-continuous-integration-action@1.40.1
-        env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
-          "INFECTION_DASHBOARD_API_KEY": ${{ secrets.INFECTION_DASHBOARD_API_KEY }}
-          "STRYKER_DASHBOARD_API_KEY": ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
+      - uses: "actions/checkout@v4"
+      - uses: "shivammathur/setup-php@v2"
         with:
-          job: ${{ matrix.job }}
+          coverage: "pcov"
+          php-version: "${{ env.PHP_CURRENT }}"
+          ini-values: "${{ env.INI_VALUES }}"
+          tools: composer-normalize, composer-require-checker
+      - uses: "ramsey/composer-install@v3"
+
+      - run: "composer validate --strict"
+      - run: "composer-normalize --dry-run"
+
+  coding-standards:
+    name: "Coding Standards"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ env.PHP_CURRENT }}"
+          ini-values: "${{ env.INI_VALUES }}"
+          tools: cs2pr
+      - uses: "ramsey/composer-install@v3"
+
+      - run: "vendor/bin/phpcs -q --report=checkstyle | cs2pr"
+
+  static-analysis:
+    name: "Static Analysis"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ env.PHP_CURRENT }}"
+          ini-values: "${{ env.INI_VALUES }}"
+      - uses: "ramsey/composer-install@v3"
+
+      - run: "vendor/bin/psalm --shepherd --stats --output-format=github --no-cache"
+
+  tests:
+    name: "Tests"
+    runs-on: "ubuntu-latest"
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.2"
+          - "8.3"
+        dependencies:
+          - "lowest"
+          - "locked"
+          - "highest"
+
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "pcov"
+          php-version: "${{ matrix.php-version }}"
+          ini-values: "${{ env.INI_VALUES }}"
+      - uses: "ramsey/composer-install@v3"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
+
+      - name: "Run tests"
+        timeout-minutes: 3
+        run: "vendor/bin/phpunit --no-coverage --no-logging"
+
+  code-coverage:
+    name: "Code Coverage"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/checkout@v4"
+      - uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "pcov"
+          php-version: "${{ env.PHP_CURRENT }}"
+          ini-values: "${{ env.INI_VALUES }}"
+      - uses: "ramsey/composer-install@v3"
+
+      - name: "Run Infection"
+        timeout-minutes: 30
+        run: "vendor/bin/roave-infection-static-analysis-plugin"
+        env:
+          INFECTION_DASHBOARD_API_KEY: "${{ secrets.INFECTION_DASHBOARD_API_KEY }}"
+          STRYKER_DASHBOARD_API_KEY: "${{ secrets.STRYKER_DASHBOARD_API_KEY }}"

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -5,7 +5,6 @@
         ]
     },
     "logs": {
-        "text": "php:\/\/stderr",
         "stryker": {
             "report": "/^\\d\\.\\d\\.x$/"
         }


### PR DESCRIPTION
We need to get this package forward, https://github.com/laminas/laminas-continuous-integration-action/issues/130 is a blocker